### PR TITLE
Make the gem work without money-rails

### DIFF
--- a/lib/money_with_date.rb
+++ b/lib/money_with_date.rb
@@ -16,5 +16,5 @@ require_relative "money_with_date/rates_store/memory"
 ::Money.date_determines_equality = false
 ::Money.default_date = ::Date.respond_to?(:current) ? -> { ::Date.current } : -> { ::Date.today }
 
-require "money_with_date/railtie" if defined?(::Rails::Railtie)
+require "money_with_date/railtie" if defined?(::Rails::Railtie) && defined?(::MoneyRails)
 # :nocov:


### PR DESCRIPTION
This PR fixes the issue when money-rails is not present in the Gemfile and the application fails with the following error:
```
lib/money_with_date/hooks.rb:18:in `init?': uninitialized constant MoneyRails
```
