### PR TITLE
Update Rails versions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,14 @@ jobs:
         ruby: ['2.6', '2.7', '3.0', '3.1']
         money: ['6.14.0', '6.14.1', '6.16.0']
         money_rails: ['1.15.0']
-        rails: ['5.2.6.2', '6.0.4.6', '6.1.4.6', '7.0.2.2']
+        rails: ['5.2.8.1', '6.0.6', '6.1.7', '7.0.4']
         exclude:
           - ruby: '3.0'
-            rails: '5.2.6.2'
+            rails: '5.2.8.1'
           - ruby: '3.1'
-            rails: '5.2.6.2'
+            rails: '5.2.8.1'
           - ruby: '2.6'
-            rails: '7.0.2.2'
+            rails: '7.0.4'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/README.md
+++ b/README.md
@@ -338,11 +338,11 @@ Money.default_date_column = nil
 
 The gem has been tested against all possible combinations of supported Ruby, Rails, money, and money-rails versions:
 - Ruby: `2.6`, `2.7`, `3.0`, and `3.1`
-- Rails: `5.2.6.2`, `6.0.4.6`, `6.1.4.6`, and `7.0.2.2`
+- Rails: `5.2.8.1`, `6.0.6`, `6.1.7`, `7.0.4`
 - money: `6.14.0`, `6.14.1`, and `6.16.0`
 - money-rails: `1.15.0`
 
-Note: the gem hasn't been tested on Rails `5.2.6.2` with Rubies `3.0` and `3.1`, and on Rails `7.0.2.2` with Ruby `2.6` as those combinations of versions aren't compatible.
+Note: the gem hasn't been tested on Rails `5.2.8.1` with Rubies `3.0` and `3.1`, and on Rails `7.0.4` with Ruby `2.6` as those combinations of versions aren't compatible.
 
 In addition to running its own test suite, the CI for this gem also runs [money's](https://github.com/RubyMoney/money/tree/main/spec) and [money-rails's](https://github.com/RubyMoney/money-rails/tree/main/spec) test suites with this gem loaded, to prevent regressions. This has been achieved by cloning their test suites from GitHub and requiring this gem in their spec files. For technical information, check the CI [workflow](.github/workflows/ci.yml).
 


### PR DESCRIPTION
Updated patch versions of Rails against which the gem is tested.

5.2.6.2 -> 5.2.8.1
6.0.4.6 -> 6.0.6
6.1.4.6 -> 6.1.7
7.0.2.2 -> 7.0.4