### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,25 +3,23 @@ name: CI
 on:
   push:
 
-env:
-  BUNDLE_GEMFILE: Gemfile_test
-
 jobs:
   lint:
     runs-on: ubuntu-latest
     name: rake rubocop
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.2'
         bundler-cache: true
     - name: Run rubocop
       run: bundle exec rake rubocop
   test:
     runs-on: ubuntu-latest
     env:
+      BUNDLE_GEMFILE: Gemfile_test
       MONEY_VERSION: ${{ matrix.money }}
       MONEY_RAILS_VERSION: ${{ matrix.money_rails }}
       RAILS_VERSION: ${{ matrix.rails }}
@@ -29,19 +27,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
         money: ['6.14.0', '6.14.1', '6.16.0']
         money_rails: ['1.15.0']
-        rails: ['5.2.8.1', '6.0.6', '6.1.7', '7.0.4']
+        rails: ['~> 5.2.0', '~> 6.0.0', '~> 6.1.0', '~> 7.0.0', '~> 7.1.0']
         exclude:
-          - ruby: '3.0'
-            rails: '5.2.8.1'
-          - ruby: '3.1'
-            rails: '5.2.8.1'
           - ruby: '2.6'
-            rails: '7.0.4'
+            rails: '~> 7.0.0'
+          - ruby: '2.6'
+            rails: '~> 7.1.0'
+          - ruby: '3.0'
+            rails: '~> 5.2.0'
+          - ruby: '3.1'
+            rails: '~> 5.2.0'
+          - ruby: '3.2'
+            rails: '~> 5.2.0'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -52,15 +54,16 @@ jobs:
   test_money:
     runs-on: ubuntu-latest
     env:
+      BUNDLE_GEMFILE: Gemfile_test
       MONEY_VERSION: ${{ matrix.money }}
     name: 'rake "spec:money[${{ matrix.money }}]" (Ruby ${{ matrix.ruby }})'
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
         money: ['6.14.0', '6.14.1', '6.16.0']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -71,16 +74,17 @@ jobs:
   test_money_rails:
     runs-on: ubuntu-latest
     env:
+      BUNDLE_GEMFILE: Gemfile_test
       MONEY_RAILS_VERSION: ${{ matrix.money_rails }}
     name: 'rake "spec:money_rails[${{ matrix.money_rails }}]" (Ruby ${{ matrix.ruby }})'
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
         money_rails: ['1.15.0']
         mongodb: ['4.4']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /spec_money/
 /spec_money_rails/
 /vendor/
+.ruby-version
 
 # rspec failure tracking
 .rspec_status

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    money_with_date (0.2.0)
+    money_with_date (0.3.0)
       money (>= 6.14.0, <= 6.16.0)
 
 GEM
@@ -9,9 +9,9 @@ GEM
   specs:
     ast (2.4.2)
     coderay (1.1.3)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
     money (6.16.0)

--- a/Gemfile_test
+++ b/Gemfile_test
@@ -4,9 +4,9 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "money", ENV["MONEY_VERSION"]
-gem "money-rails", ENV["MONEY_RAILS_VERSION"]
-gem "activerecord", ENV["RAILS_VERSION"]
+gem "money", ENV["MONEY_VERSION"] if ENV["MONEY_VERSION"]
+gem "money-rails", ENV["MONEY_RAILS_VERSION"] if ENV["MONEY_RAILS_VERSION"]
+gem "activerecord", ENV["RAILS_VERSION"] if ENV["RAILS_VERSION"]
 gem "sqlite3"
 gem "rubyzip"
 gem "simplecov", require: false

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Ruby library which extends the popular [money](https://github.com/RubyMoney/money) and [money-rails](https://github.com/RubyMoney/money-rails) gems with support for dated Money objects.
 
-Dated Money objects are useful in situations where you have to exchange money between currencies based on historical exchange rates, and you'd like to keep date information on the Money object itself. 
+Dated Money objects are useful in situations where you have to exchange money between currencies based on historical exchange rates, and you'd like to keep date information on the Money object itself.
 
 ## Installation
 
@@ -337,12 +337,16 @@ Money.default_date_column = nil
 - money-rails: **1.15.0**
 
 The gem has been tested against all possible combinations of supported Ruby, Rails, money, and money-rails versions:
-- Ruby: `2.6`, `2.7`, `3.0`, and `3.1`
-- Rails: `5.2.8.1`, `6.0.6`, `6.1.7`, `7.0.4`
+- Ruby: `2.6`, `2.7`, `3.0`, `3.1` and `3.2`
+- Rails: `~> 5.2.0`, `~> 6.0.0`, `~> 6.1.0`, `~> 7.0.0` and `~> 7.1.0`
 - money: `6.14.0`, `6.14.1`, and `6.16.0`
 - money-rails: `1.15.0`
 
-Note: the gem hasn't been tested on Rails `5.2.8.1` with Rubies `3.0` and `3.1`, and on Rails `7.0.4` with Ruby `2.6` as those combinations of versions aren't compatible.
+The following combinations have been excluded from the test matrix because of incompatibility:
+- Ruby `2.6` with Rails `~> 7.0.0` and `~> 7.1.0`
+- Ruby `3.0` with Rails `~> 5.2.0`
+- Ruby `3.1` with Rails `~> 5.2.0`
+- Ruby `3.2` with Rails `~> 5.2.0`
 
 In addition to running its own test suite, the CI for this gem also runs [money's](https://github.com/RubyMoney/money/tree/main/spec) and [money-rails's](https://github.com/RubyMoney/money-rails/tree/main/spec) test suites with this gem loaded, to prevent regressions. This has been achieved by cloning their test suites from GitHub and requiring this gem in their spec files. For technical information, check the CI [workflow](.github/workflows/ci.yml).
 

--- a/bin/prepare_money_specs
+++ b/bin/prepare_money_specs
@@ -45,6 +45,14 @@ spec_helper = spec_helper.gsub('require "money"', 'require "money_with_date"')
 spec_helper = spec_helper.gsub("./spec/support/**/*.rb", "./spec_money/support/**/*.rb")
 File.write("#{destination_folder_path}/spec_helper.rb", spec_helper)
 
+# Patching YAML spec failing because of Psych gem update
+patch_url = "https://github.com/RubyMoney/money/commit/9de53057f3089c98e2bf37f8d6b2e924ec7e52de.patch"
+IO.copy_stream(URI.open(patch_url), "#{destination_folder_path}/yaml.patch") # rubocop:disable Security/Open
+yaml_patch = File.read("#{destination_folder_path}/yaml.patch")
+yaml_patch = yaml_patch.gsub("spec/money_spec.rb", "spec_money/money_spec.rb")
+File.write("#{destination_folder_path}/yaml.patch", yaml_patch)
+system("git apply --include=spec_money/money_spec.rb spec_money/yaml.patch") || (raise "YAML spec patch error")
+
 # Adding a simple spec to verify that money_with_date has been loaded
 File.open("#{destination_folder_path}/money_with_date_spec.rb", "w") do |f|
   f << <<~RUBY

--- a/lib/money_with_date/bank/variable_exchange.rb
+++ b/lib/money_with_date/bank/variable_exchange.rb
@@ -54,7 +54,7 @@ module MoneyWithDate
       def rates
         return super if store.method(:get_rate).parameters.size == 2
 
-        store.each_rate.each_with_object({}) do |(from, to, rate, date), hash|
+        store.each_rate.with_object({}) do |(from, to, rate, date), hash|
           hash[date.to_s] ||= {}
           hash[date.to_s][[from, to].join(SERIALIZER_SEPARATOR)] = rate
         end

--- a/lib/money_with_date/instance_methods.rb
+++ b/lib/money_with_date/instance_methods.rb
@@ -19,7 +19,7 @@ module MoneyWithDate
     def hash
       return super unless ::Money.date_determines_equality
 
-      [fractional.hash, currency.hash, date.hash].hash # rubocop:disable Security/CompoundHash
+      [fractional.hash, currency.hash, date.hash].hash
     end
 
     def inspect

--- a/spec/money_with_date/rates_store/memory_spec.rb
+++ b/spec/money_with_date/rates_store/memory_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe MoneyWithDate::RatesStore::Memory do
 
     it "is an Enumeator" do
       expect(subject.each_rate).to be_kind_of(Enumerator)
-      result = subject.each_rate.each_with_object({}) { |(from, to, rate), m| m[[from, to].join] = rate }
+      result = subject.each_rate.with_object({}) { |(from, to, rate), m| m[[from, to].join] = rate }
       expect(result).to match({ "USDCAD" => 0.9, "CADUSD" => 1.1 })
     end
   end


### PR DESCRIPTION
- Upgrade actions/checkout to v4
- Test against Ruby 3.2 and Rails 7.1
- Fix Rubocop offenses
- Refactor Rails versions in the CI to automatically pick the latest patch version
- Patch failing YAML spec in money test suite 